### PR TITLE
Add FastAPI OpenAI-compatible endpoint for ask command

### DIFF
--- a/src/cbioportal_mcp_qa/api.py
+++ b/src/cbioportal_mcp_qa/api.py
@@ -1,0 +1,100 @@
+"""FastAPI wrapper exposing the ask command with an OpenAI-compatible interface."""
+
+from typing import Any, List, Optional
+
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel, ConfigDict, Field
+from starlette.responses import JSONResponse, StreamingResponse
+
+from .openai_adapter import chat_completion_response, sse_chat_completions
+
+from .llm_client import DEFAULT_MODEL, LLMClient
+from .sql_logger import sql_query_logger
+
+DEFAULT_CHUNK_SIZE = 1200
+
+app = FastAPI()
+
+
+class Message(BaseModel):
+    role: str = Field(..., description="Role of the message sender (e.g., user).")
+    content: str
+
+
+class ChatCompletionRequest(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+    messages: List[Message]
+    stream: bool = True
+    include_sql: bool = True
+
+
+def _extract_user_question(messages: List[Message]) -> Optional[str]:
+    """Return the most recent user message content."""
+    for message in reversed(messages):
+        if message.role.lower() == "user":
+            return message.content
+    return None
+
+
+def _chunk_answer(answer: str, chunk_size: int = DEFAULT_CHUNK_SIZE) -> List[str]:
+    """Split the answer into smaller pieces to feed the SSE adapter."""
+    if not answer:
+        return [""]
+    return [answer[i : i + chunk_size] for i in range(0, len(answer), chunk_size)]
+
+
+@app.post("/chat/completions")
+async def chat_completions(chat_request: ChatCompletionRequest):
+    print("-- -- [api] incoming request", chat_request.model_dump(exclude_none=True))
+    if getattr(chat_request, "model_extra", None):
+        print("-- -- [api] extra params ignored", chat_request.model_extra)
+
+    question = _extract_user_question(chat_request.messages)
+    if not question:
+        raise HTTPException(
+            status_code=400, detail="A user message is required to ask a question."
+        )
+
+    try:
+        llm_client = LLMClient(
+            model=DEFAULT_MODEL,
+            include_sql=chat_request.include_sql,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+
+    answer = await llm_client.ask_question(question)
+
+    if chat_request.include_sql:
+        sql_markdown = sql_query_logger.get_queries_markdown()
+        if sql_markdown:
+            answer = f"{answer}\n\n---\n{sql_markdown}"
+
+    chunks = _chunk_answer(answer)
+
+    if chat_request.stream:
+        print(
+            "-- -- [api] streaming response body",
+            {"model_used": DEFAULT_MODEL, "chunk_count": len(chunks), "chunks": chunks},
+        )
+        return StreamingResponse(
+            sse_chat_completions(chunks, model=DEFAULT_MODEL),
+            media_type="text/event-stream",
+        )
+
+    payload = chat_completion_response(
+        chunk_iterable=chunks,
+        model=DEFAULT_MODEL,
+        prompt_messages=[message.content for message in chat_request.messages],
+    )
+    print(
+        "-- -- [api] json response body",
+        {"model_used": DEFAULT_MODEL, "payload": payload},
+    )
+    return JSONResponse(payload)
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run("cbioportal_mcp_qa.api:app", host="0.0.0.0", port=4000, reload=False)

--- a/src/cbioportal_mcp_qa/llm_client copy.py
+++ b/src/cbioportal_mcp_qa/llm_client copy.py
@@ -1,0 +1,159 @@
+"""PydanticAI client with MCP ClickHouse integration."""
+
+import os
+import asyncio
+import time
+import json
+from typing import Optional, List, Dict, Any
+
+from pydantic_ai import Agent
+from pydantic_ai.mcp import MCPServerStdio
+from pydantic_ai.settings import ModelSettings
+from pydantic_ai.models.openai import OpenAIChatModel
+from pydantic_ai.providers.openai import OpenAIProvider
+
+DEFAULT_MODEL = "anthropic:claude-sonnet-4-20250514"
+DEFAULT_OLLAMA_BASE_URL = "http://localhost:11434"
+
+from .prompts import DEFAULT_SYSTEM_PROMPT
+from .sql_logger import sql_query_logger, MCPServerStdioWithSQLCapture
+
+
+class LLMClient:
+    """PydanticAI client with MCP ClickHouse integration."""
+    
+    def get_sql_queries(self) -> List[Any]:
+        """Get captured SQL queries for the current question.
+        
+        Returns:
+            List of SqlQuery objects
+        """
+        return sql_query_logger.get_queries()
+    
+    def __init__(
+        self, 
+        api_key: Optional[str] = None,
+        model: str = DEFAULT_MODEL,
+        use_ollama: bool = False,
+        ollama_base_url: str = DEFAULT_OLLAMA_BASE_URL,
+        clickhouse_host: Optional[str] = None,
+        clickhouse_database: Optional[str] = None,
+        clickhouse_port: Optional[str] = None,
+        clickhouse_user: Optional[str] = None,
+        clickhouse_password: Optional[str] = None,
+        clickhouse_secure: Optional[str] = None,
+        clickhouse_verify: Optional[str] = None,
+        clickhouse_connect_timeout: Optional[str] = None,
+        clickhouse_send_receive_timeout: Optional[str] = None,
+        include_sql: bool = False,
+        enable_open_telemetry_tracing: bool = False,
+    ):
+        """Initialize the client.
+        
+        Args:
+            api_key: Anthropic API key. If None, will read from ANTHROPIC_API_KEY env var.
+            model: Model to use (Anthropic or Ollama format).
+            use_ollama: Whether to use Ollama instead of Anthropic.
+            ollama_base_url: Base URL for Ollama server.
+            clickhouse_*: ClickHouse configuration parameters.
+            include_sql: Whether to capture and log SQL queries.
+            enable_open_telemetry_tracing: Whether to capture traces with Arize Phoenix
+        """
+        # Only require API key for Anthropic models
+        if not use_ollama:
+            api_key = api_key or os.getenv("ANTHROPIC_API_KEY")
+            if not api_key:
+                raise ValueError("ANTHROPIC_API_KEY environment variable must be set")
+        
+        # Set up ClickHouse environment variables
+        clickhouse_env = {}
+        
+        # Add required parameters
+        clickhouse_env["CLICKHOUSE_HOST"] = clickhouse_host or os.getenv("CLICKHOUSE_HOST")
+        clickhouse_env["CLICKHOUSE_DATABASE"] = clickhouse_database or os.getenv("CLICKHOUSE_DATABASE")
+        clickhouse_env["CLICKHOUSE_USER"] = clickhouse_user or os.getenv("CLICKHOUSE_USER")
+        clickhouse_env["CLICKHOUSE_PASSWORD"] = clickhouse_password or os.getenv("CLICKHOUSE_PASSWORD")
+        
+        # Add optional parameters only if they have values
+        optional_params = {
+            "CLICKHOUSE_PORT": clickhouse_port or os.getenv("CLICKHOUSE_PORT"),
+            "CLICKHOUSE_SECURE": clickhouse_secure or os.getenv("CLICKHOUSE_SECURE"),
+            "CLICKHOUSE_VERIFY": clickhouse_verify or os.getenv("CLICKHOUSE_VERIFY"),
+            "CLICKHOUSE_CONNECT_TIMEOUT": clickhouse_connect_timeout or os.getenv("CLICKHOUSE_CONNECT_TIMEOUT"),
+            "CLICKHOUSE_SEND_RECEIVE_TIMEOUT": clickhouse_send_receive_timeout or os.getenv("CLICKHOUSE_SEND_RECEIVE_TIMEOUT"),
+        }
+        
+        for key, value in optional_params.items():
+            if value is not None:
+                clickhouse_env[key] = value
+        
+        # Check for required ClickHouse parameters
+        required_params = ["CLICKHOUSE_HOST", "CLICKHOUSE_DATABASE", "CLICKHOUSE_USER", "CLICKHOUSE_PASSWORD"]
+        missing_params = [param for param in required_params if not clickhouse_env.get(param)]
+        
+        if missing_params:
+            raise ValueError(f"Missing required ClickHouse parameters: {', '.join(missing_params)}")
+        
+        # Configure SQL logging
+        if include_sql:
+            sql_query_logger.enable()
+        else:
+            sql_query_logger.disable()
+        
+        # Configure MCP server with ClickHouse
+        if include_sql:
+            self.mcp_server = MCPServerStdioWithSQLCapture(
+                sql_query_logger,
+                command="cbioportal-mcp",
+                args=[],
+                env=clickhouse_env
+            )
+        else:
+            self.mcp_server = MCPServerStdio(
+                command="cbioportal-mcp",
+                args=[],
+                env=clickhouse_env
+            )
+        
+        # Create agent with MCP server
+        model_settings = ModelSettings(max_tokens=4096, temperature=0.0)
+        
+        # Create model based on whether using Ollama or Anthropic
+        if use_ollama:
+            # For Ollama, create OpenAI-compatible model
+            agent_model = OpenAIChatModel(
+                model_name=model,  # This should be the ollama_model passed from main.py
+                provider=OpenAIProvider(base_url=f"{ollama_base_url}/v1")
+            )
+        else:
+            # For Anthropic, use model string directly
+            agent_model = model
+        
+        self.agent = Agent(
+            agent_model,
+            toolsets=[self.mcp_server],
+            system_prompt=DEFAULT_SYSTEM_PROMPT,
+            model_settings=model_settings,
+            instrument=enable_open_telemetry_tracing
+        )
+        
+    async def ask_question(self, question: str) -> str:
+        """Ask a question using PydanticAI with MCP integration.
+        
+        Args:
+            question: The question to ask
+            
+        Returns:
+            The response from the agent
+        """
+        try:
+            # Clear previous queries for this question
+            sql_query_logger.clear()
+            
+            # Use the agent's run_mcp_servers context manager
+            async with self.agent:
+                response = await self.agent.run(question)
+                return response.output
+        
+        except Exception as e:
+            return f"Error processing question: {str(e)}"

--- a/src/cbioportal_mcp_qa/openai_adapter.py
+++ b/src/cbioportal_mcp_qa/openai_adapter.py
@@ -1,0 +1,113 @@
+"""
+Helpers to format chat responses in OpenAI-compatible shapes (streaming and non-streaming).
+"""
+import json
+import time
+import uuid
+from typing import AsyncGenerator, Iterable, List, Optional
+
+
+def _default_ids(created: Optional[int] = None, completion_id: Optional[str] = None):
+    created_ts = created or int(time.time())
+    cid = completion_id or f"chatcmpl-{uuid.uuid4()}"
+    return created_ts, cid
+
+
+async def sse_chat_completions(
+    chunk_iterable: Iterable[str],
+    model: str,
+    created: Optional[int] = None,
+    completion_id: Optional[str] = None,
+) -> AsyncGenerator[str, None]:
+    """
+    Wrap a string chunk iterable into OpenAI-style SSE ChatCompletions chunks.
+    Yields already-serialized `data: ...\\n\\n` frames and ends with [DONE].
+    """
+    created_ts, cid = _default_ids(created, completion_id)
+    for chunk in chunk_iterable:
+        frame = {
+            "id": cid,
+            "object": "chat.completion.chunk",
+            "created": created_ts,
+            "model": model,
+            "choices": [
+                {
+                    "index": 0,
+                    "delta": {
+                        "role": "assistant",
+                        "content": chunk,
+                    },
+                    "finish_reason": None,
+                }
+            ],
+        }
+        yield f"data: {json.dumps(frame)}\n\n"
+        await _small_sleep()
+
+    final_frame = {
+        "id": cid,
+        "object": "chat.completion.chunk",
+        "created": created_ts,
+        "model": model,
+        "choices": [
+            {
+                "index": 0,
+                "delta": {},
+                "finish_reason": "stop",
+            }
+        ],
+    }
+    yield f"data: {json.dumps(final_frame)}\n\n"
+    yield "data: [DONE]\n\n"
+
+
+async def _small_sleep():
+    # Tiny async pause to keep the event loop responsive.
+    await _asyncio_sleep(0.01)
+
+
+async def _asyncio_sleep(delay: float):
+    import asyncio
+
+    await asyncio.sleep(delay)
+
+
+def chat_completion_response(
+    chunk_iterable: Iterable[str],
+    model: str,
+    prompt_messages: Optional[List[str]] = None,
+    created: Optional[int] = None,
+    completion_id: Optional[str] = None,
+):
+    """
+    Build a full ChatCompletions response from an iterable of text chunks.
+    Token counts are rough (word splits); replace with a real tokenizer if needed.
+    """
+    created_ts, cid = _default_ids(created, completion_id)
+    content = "".join(chunk_iterable)
+    prompt_text = " ".join(prompt_messages or [])
+    prompt_tokens = len(prompt_text.split()) if prompt_text else 0
+    completion_tokens = len(content.split())
+
+    return {
+        "id": cid,
+        "object": "chat.completion",
+        "created": created_ts,
+        "model": model,
+        "choices": [
+            {
+                "index": 0,
+                "message": {
+                    "role": "assistant",
+                    "content": content,
+                },
+                "finish_reason": "stop",
+            }
+        ],
+        "usage": {
+            "prompt_tokens": prompt_tokens,
+            "completion_tokens": completion_tokens,
+            "total_tokens": prompt_tokens + completion_tokens,
+        },
+    }
+


### PR DESCRIPTION
Expose an OpenAI-compatible /chat/completions endpoint (via FastAPI) so LibreChat can call our agent as a custom endpoint. This keeps the same request/response shape while letting us fully track and control the agent behavior in our stack.