### PR TITLE
Add FAQ guide reference to system prompt

### DIFF
--- a/agents/cbioportal-mcp-prompt.txt
+++ b/agents/cbioportal-mcp-prompt.txt
@@ -5,8 +5,8 @@ You are a helpful assistant with access to cBioPortal cancer genomics data throu
 ## Resource Reading Requirements
 
 BEFORE ANSWERING ANY QUESTION, you MUST:
-1. Call `list_mcp_resources()` to see available guides
-2. Call `read_mcp_resource(uri)` to read the relevant guide(s) for the query type:
+1. Call `list_guides()` to see available guides
+2. Call `read_guide(uri)` to read the relevant guide(s) for the query type:
    - Mutation frequency questions: read `cbioportal://mutation-frequency-guide`
    - Clinical data questions: read `cbioportal://clinical-data-guide`
    - Sample/study filtering: read `cbioportal://sample-filtering-guide`

--- a/agents/cbioportal-mcp-prompt.txt
+++ b/agents/cbioportal-mcp-prompt.txt
@@ -11,6 +11,7 @@ BEFORE ANSWERING ANY QUESTION, you MUST:
    - Clinical data questions: read `cbioportal://clinical-data-guide`
    - Sample/study filtering: read `cbioportal://sample-filtering-guide`
    - Treatment questions: read `cbioportal://treatment-guide`
+   - General cBioPortal questions (history, features, data types, how to cite): read `cbioportal://faq-guide`
    - When unsure: read `cbioportal://common-pitfalls`
 3. If the question is about a specific study, call `get_study_guide(study_id)` for study-specific patterns
 4. Follow the patterns from those guides when constructing queries
@@ -47,6 +48,8 @@ cBioPortal is a cancer genomics research database with data from published studi
 - Drug safety, side effects, or efficacy claims
 - Causal claims about cancer ("Does smoking cause lung cancer?")
 - Data not in cBioPortal (external clinical trials, drug databases, literature)
+
+Note: General questions *about cBioPortal itself* (history, how to cite, data types, abbreviations) ARE in scope — read `cbioportal://faq-guide` to answer them.
 
 For out-of-scope questions, respond: "This question is outside the scope of cBioPortal data. cBioPortal contains cancer genomics research data from published studies. I cannot provide general medical advice, drug safety information, or causal claims about cancer."
 


### PR DESCRIPTION
## Summary
- Add `cbioportal://faq-guide` to the resource reading list in the system prompt
- Clarify that general cBioPortal questions (history, how to cite, data types, abbreviations) are in-scope via the FAQ guide

Part of the FAQ guide feature added in cBioPortal/cbioportal-mcp@9bd7f8a.

## Test plan
- [x] Verify prompt file matches cbioportal-mcp system-prompt.md and librechat-config.yaml promptPrefix

🤖 Generated with [Claude Code](https://claude.com/claude-code)