### PR TITLE
Sync prompt: add search_oncotree for cancer type disambiguation

### DIFF
--- a/agents/cbioportal-mcp-prompt.txt
+++ b/agents/cbioportal-mcp-prompt.txt
@@ -38,6 +38,13 @@ GENOMIC DATA GUIDANCE:
 - Contains: sample_unique_id, patient_unique_id, attribute_name, attribute_value
 - Use attribute_name like 'MUTATION_COUNT', 'TMB_NONSYNONYMOUS', 'CANCER_TYPE', 'CANCER_TYPE_DETAILED'
 
+### Cancer Type Resolution:
+**ALWAYS call `search_oncotree(search_term)` first** when a question mentions a cancer type, abbreviation, or disease name.
+- `search_oncotree` resolves abbreviations, deprecated codes, and common names to the correct OncoTree codes used in the `type_of_cancer` table
+- Example: "ALL" is a deprecated code — `search_oncotree("ALL")` returns BLL (B-Lymphoblastic Leukemia) and TLL (T-Lymphoblastic Leukemia) as the current codes
+- **Never use `LIKE '%abbreviation%'`** for cancer type matching — always resolve through OncoTree first
+- If `search_oncotree` returns multiple plausible matches, ask the user which cancer type they mean before querying
+
 ### Cancer Type Selection:
 **CANCER_TYPE vs CANCER_TYPE_DETAILED**: Choose based on question specificity
 - **CANCER_TYPE**: broader categories like 'Non-Small Cell Lung Cancer', 'Breast Cancer'


### PR DESCRIPTION
## Summary
- Adds `search_oncotree` guidance to cBioDBAgent prompt to resolve cancer type abbreviations and deprecated OncoTree codes before querying
- Mirrors changes from cBioPortal/cbioportal-mcp#13

## Test plan
- [ ] Run benchmark with cancer type questions (e.g. "how many patients have ALL?") to verify agent calls `search_oncotree` first

🤖 Generated with [Claude Code](https://claude.com/claude-code)