### PR TITLE
Add nightly drift benchmark workflow

### DIFF
--- a/.github/workflows/nightly-drift-benchmark.yml
+++ b/.github/workflows/nightly-drift-benchmark.yml
@@ -1,0 +1,104 @@
+name: Nightly Drift Benchmark
+
+on:
+  schedule:
+    - cron: "0 7 * * *"
+  workflow_dispatch:
+    inputs:
+      agent_types:
+        description: "Comma-separated agent types to benchmark"
+        required: false
+        default: "mcp-clickhouse,mcp-navigator-agent"
+      questions:
+        description: "Question selection, e.g. all, 1-20, 1,3,5"
+        required: false
+        default: "1-20"
+      reproducibility_runs:
+        description: "Number of reproducibility runs; 0 disables reproducibility"
+        required: false
+        default: "0"
+      drop_threshold:
+        description: "Per-question score drop that counts as drift"
+        required: false
+        default: "1.0"
+      fail_on_regression:
+        description: "Fail workflow when drift report detects regressions"
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+
+    env:
+      AGENT_TYPES: ${{ github.event.inputs.agent_types || 'mcp-clickhouse,mcp-navigator-agent' }}
+      QUESTIONS: ${{ github.event.inputs.questions || '1-20' }}
+      REPRODUCIBILITY_RUNS: ${{ github.event.inputs.reproducibility_runs || '0' }}
+      DROP_THRESHOLD: ${{ github.event.inputs.drop_threshold || '1.0' }}
+      FAIL_ON_REGRESSION: ${{ github.event.inputs.fail_on_regression || 'false' }}
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      MCP_CLICKHOUSE_AGENT_URL: ${{ secrets.MCP_CLICKHOUSE_AGENT_URL }}
+      CBIOPORTAL_MCP_AGENT_URL: ${{ secrets.CBIOPORTAL_MCP_AGENT_URL }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v5
+
+      - name: Install dependencies
+        run: uv sync --extra dev
+
+      - name: Run nightly benchmark and drift reports
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          run_date="$(date -u +%Y%m%d)"
+          mkdir -p drift-reports
+
+          IFS=',' read -ra agents <<< "$AGENT_TYPES"
+          for raw_agent in "${agents[@]}"; do
+            agent="$(echo "$raw_agent" | xargs)"
+            if [[ -z "$agent" ]]; then
+              continue
+            fi
+
+            echo "## Benchmark: ${agent}" | tee -a "$GITHUB_STEP_SUMMARY"
+            echo "" | tee -a "$GITHUB_STEP_SUMMARY"
+
+            uv run cbioportal-mcp-qa benchmark \
+              --agent-type "$agent" \
+              --questions "$QUESTIONS" \
+              --delay 5 \
+              --batch-size 5 \
+              --reproducibility-runs "$REPRODUCIBILITY_RUNS"
+
+            fail_args=()
+            if [[ "$FAIL_ON_REGRESSION" == "true" ]]; then
+              fail_args+=(--fail-on-regression)
+            fi
+
+            uv run python -m cbioportal_mcp_qa.drift_report \
+              --agent-type "$agent" \
+              --current-eval-dir "results/${agent}/${run_date}/eval" \
+              --baseline-eval-dir "results/${agent}/latest/eval" \
+              --output-markdown "drift-reports/${agent}.md" \
+              --output-json "drift-reports/${agent}.json" \
+              --drop-threshold "$DROP_THRESHOLD" \
+              "${fail_args[@]}"
+
+            cat "drift-reports/${agent}.md" >> "$GITHUB_STEP_SUMMARY"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+          done
+
+      - name: Upload benchmark artifacts
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: nightly-drift-benchmark-${{ github.run_id }}
+          path: |
+            results/
+            drift-reports/
+            LEADERBOARD.md

--- a/README.md
+++ b/README.md
@@ -95,6 +95,47 @@ cbioportal-mcp-qa benchmark --agent-type mcp-clickhouse --questions 1-10 -r 5
 3.  All pairwise combinations of runs are compared using an LLM judge for semantic equivalence.
 4.  A `reproducibility_score` is added to the evaluation results and leaderboard.
 
+## Nightly Drift Monitoring
+
+The `Nightly Drift Benchmark` GitHub Actions workflow runs the benchmark on a
+schedule and compares each run against the checked-in `results/{agent}/latest`
+baseline.
+
+By default it runs the canary range `1-20` against:
+
+- `mcp-clickhouse`
+- `mcp-navigator-agent`
+
+Required repository secrets:
+
+- `ANTHROPIC_API_KEY`: LLM judge key.
+- `MCP_CLICKHOUSE_AGENT_URL`: Base URL for the DB MCP agent wrapper.
+- `CBIOPORTAL_MCP_AGENT_URL`: Base URL for the navigator MCP agent wrapper.
+
+Manual runs can override the target agents, questions, reproducibility count,
+and regression threshold from the Actions UI. Example agent list:
+
+```text
+mcp-clickhouse,mcp-navigator-agent
+```
+
+Each nightly run uploads:
+
+- `results/`: generated answers and evaluation CSVs.
+- `drift-reports/*.md`: human-readable score deltas and per-question regressions.
+- `drift-reports/*.json`: machine-readable drift summaries.
+- `LEADERBOARD.md`: regenerated aggregate leaderboard for the run artifact.
+
+Interpret target-specific drift as follows:
+
+- Fails only on one MCP target: likely an isolated agent/service issue.
+- Fails on multiple MCP targets: likely shared data, evaluator, or model drift.
+- Fails in reproducibility only: likely nondeterministic agent/model behavior.
+
+The workflow is monitoring-first. It does not fail on regressions unless
+`fail_on_regression` is enabled for a manual run or the workflow default is
+changed.
+
 ## Manual Usage (CLI Reference)
 
 You can also run individual components manually.

--- a/src/cbioportal_mcp_qa/benchmark.py
+++ b/src/cbioportal_mcp_qa/benchmark.py
@@ -44,6 +44,7 @@ async def run_benchmark(
     skip_eval: bool = False,
     eval_only: bool = False,
     reproducibility_runs: int = 0,
+    enable_open_telemetry_tracing: bool = False,
 ):
     """
     Runs the benchmark for a specific agent type.
@@ -144,7 +145,6 @@ async def run_benchmark(
                 use_bedrock=use_bedrock,
                 aws_profile=aws_profile,
                 include_sql=include_sql,
-                enable_open_telemetry_tracing=enable_open_telemetry_tracing,
                 delay=delay,
                 batch_size=batch_size,
             )

--- a/src/cbioportal_mcp_qa/drift_report.py
+++ b/src/cbioportal_mcp_qa/drift_report.py
@@ -1,0 +1,230 @@
+"""Generate drift reports by comparing benchmark runs to a baseline."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+
+
+@dataclass(frozen=True)
+class DriftSummary:
+    agent_type: str
+    current_eval: Path
+    baseline_eval: Path | None
+    current_averages: dict[str, float]
+    baseline_averages: dict[str, float]
+    average_deltas: dict[str, float]
+    regressions: list[dict[str, Any]]
+
+    @property
+    def has_regressions(self) -> bool:
+        return bool(self.regressions)
+
+
+def _latest_csv(eval_dir: Path, pattern: str = "evaluation_*.csv") -> Path | None:
+    candidates = sorted(eval_dir.glob(pattern), key=lambda p: p.stat().st_mtime, reverse=True)
+    return candidates[0] if candidates else None
+
+
+def _read_eval_csv(path: Path) -> pd.DataFrame:
+    return pd.read_csv(path, comment="#")
+
+
+def _score_columns(df: pd.DataFrame) -> list[str]:
+    return [col for col in df.columns if col.endswith("_score")]
+
+
+def _score_averages(df: pd.DataFrame) -> dict[str, float]:
+    return {
+        col: float(value)
+        for col, value in df[_score_columns(df)].astype(float).mean().to_dict().items()
+    }
+
+
+def _row_regressions(
+    current_df: pd.DataFrame,
+    baseline_df: pd.DataFrame,
+    drop_threshold: float,
+) -> list[dict[str, Any]]:
+    if "question" not in current_df.columns or "question" not in baseline_df.columns:
+        return []
+
+    shared_score_cols = sorted(set(_score_columns(current_df)) & set(_score_columns(baseline_df)))
+    if not shared_score_cols:
+        return []
+
+    current_clean = current_df.dropna(subset=["question"]).copy()
+    baseline_clean = baseline_df.dropna(subset=["question"]).copy()
+    current_clean["question"] = current_clean["question"].astype(str)
+    baseline_clean["question"] = baseline_clean["question"].astype(str)
+
+    current_by_question = current_clean.set_index("question")
+    baseline_by_question = baseline_clean.set_index("question")
+    shared_questions = sorted(set(current_by_question.index) & set(baseline_by_question.index))
+
+    regressions: list[dict[str, Any]] = []
+    for question in shared_questions:
+        for score_col in shared_score_cols:
+            current_value = float(current_by_question.loc[question, score_col])
+            baseline_value = float(baseline_by_question.loc[question, score_col])
+            delta = current_value - baseline_value
+            if delta <= -drop_threshold:
+                regressions.append(
+                    {
+                        "question": question,
+                        "metric": score_col,
+                        "baseline": baseline_value,
+                        "current": current_value,
+                        "delta": delta,
+                    }
+                )
+
+    regressions.sort(key=lambda row: (row["delta"], row["question"], row["metric"]))
+    return regressions
+
+
+def build_drift_summary(
+    agent_type: str,
+    current_eval_dir: Path,
+    baseline_eval_dir: Path,
+    drop_threshold: float,
+) -> DriftSummary:
+    current_eval = _latest_csv(current_eval_dir)
+    if current_eval is None:
+        raise FileNotFoundError(f"No evaluation CSV found in {current_eval_dir}")
+
+    current_df = _read_eval_csv(current_eval)
+    current_averages = _score_averages(current_df)
+
+    baseline_eval = _latest_csv(baseline_eval_dir)
+    if baseline_eval is None:
+        return DriftSummary(
+            agent_type=agent_type,
+            current_eval=current_eval,
+            baseline_eval=None,
+            current_averages=current_averages,
+            baseline_averages={},
+            average_deltas={},
+            regressions=[],
+        )
+
+    baseline_df = _read_eval_csv(baseline_eval)
+    baseline_averages = _score_averages(baseline_df)
+    average_deltas = {
+        metric: current_averages[metric] - baseline_averages[metric]
+        for metric in sorted(set(current_averages) & set(baseline_averages))
+    }
+    regressions = _row_regressions(current_df, baseline_df, drop_threshold)
+
+    return DriftSummary(
+        agent_type=agent_type,
+        current_eval=current_eval,
+        baseline_eval=baseline_eval,
+        current_averages=current_averages,
+        baseline_averages=baseline_averages,
+        average_deltas=average_deltas,
+        regressions=regressions,
+    )
+
+
+def summary_to_dict(summary: DriftSummary) -> dict[str, Any]:
+    return {
+        "agent_type": summary.agent_type,
+        "current_eval": str(summary.current_eval),
+        "baseline_eval": str(summary.baseline_eval) if summary.baseline_eval else None,
+        "current_averages": summary.current_averages,
+        "baseline_averages": summary.baseline_averages,
+        "average_deltas": summary.average_deltas,
+        "regressions": summary.regressions,
+        "has_regressions": summary.has_regressions,
+    }
+
+
+def render_markdown(summary: DriftSummary) -> str:
+    lines = [
+        f"# Drift Report: `{summary.agent_type}`",
+        "",
+        f"- Current evaluation: `{summary.current_eval}`",
+        f"- Baseline evaluation: `{summary.baseline_eval or 'not found'}`",
+        "",
+        "## Average Scores",
+        "",
+        "| Metric | Current | Baseline | Delta |",
+        "|---|---:|---:|---:|",
+    ]
+
+    metrics = sorted(set(summary.current_averages) | set(summary.baseline_averages))
+    for metric in metrics:
+        current = summary.current_averages.get(metric)
+        baseline = summary.baseline_averages.get(metric)
+        delta = summary.average_deltas.get(metric)
+        lines.append(
+            "| {metric} | {current} | {baseline} | {delta} |".format(
+                metric=metric,
+                current=f"{current:.2f}" if current is not None else "n/a",
+                baseline=f"{baseline:.2f}" if baseline is not None else "n/a",
+                delta=f"{delta:+.2f}" if delta is not None else "n/a",
+            )
+        )
+
+    lines.extend(["", "## Regressions", ""])
+    if not summary.regressions:
+        lines.append("No per-question regressions exceeded the configured threshold.")
+    else:
+        lines.extend(
+            [
+                "| Question | Metric | Baseline | Current | Delta |",
+                "|---|---|---:|---:|---:|",
+            ]
+        )
+        for regression in summary.regressions:
+            question = str(regression["question"]).replace("|", "\\|")
+            lines.append(
+                "| {question} | {metric} | {baseline:.2f} | {current:.2f} | {delta:+.2f} |".format(
+                    question=question,
+                    metric=regression["metric"],
+                    baseline=regression["baseline"],
+                    current=regression["current"],
+                    delta=regression["delta"],
+                )
+            )
+
+    return "\n".join(lines) + "\n"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--agent-type", required=True)
+    parser.add_argument("--current-eval-dir", type=Path, required=True)
+    parser.add_argument("--baseline-eval-dir", type=Path, required=True)
+    parser.add_argument("--output-markdown", type=Path, required=True)
+    parser.add_argument("--output-json", type=Path, required=True)
+    parser.add_argument("--drop-threshold", type=float, default=1.0)
+    parser.add_argument("--fail-on-regression", action="store_true")
+    args = parser.parse_args(argv)
+
+    summary = build_drift_summary(
+        agent_type=args.agent_type,
+        current_eval_dir=args.current_eval_dir,
+        baseline_eval_dir=args.baseline_eval_dir,
+        drop_threshold=args.drop_threshold,
+    )
+
+    args.output_markdown.parent.mkdir(parents=True, exist_ok=True)
+    args.output_json.parent.mkdir(parents=True, exist_ok=True)
+    args.output_markdown.write_text(render_markdown(summary), encoding="utf-8")
+    args.output_json.write_text(json.dumps(summary_to_dict(summary), indent=2), encoding="utf-8")
+
+    print(render_markdown(summary))
+    if args.fail_on_regression and summary.has_regressions:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_benchmark_demo.py
+++ b/tests/test_benchmark_demo.py
@@ -31,7 +31,7 @@ class TestBenchmarkDemo:
         End-to-end benchmark demonstration using real fixture data.
 
         This test:
-        1. Uses pre-recorded answers from results/mcp-clickhouse/20260128/
+        1. Uses pre-recorded answers from results/mcp-clickhouse/latest/
         2. Mocks the QA client (batch processor) to copy fixture answers
         3. Mocks the Anthropic client for evaluation
         4. Runs full pipeline including 3 reproducibility runs
@@ -115,7 +115,7 @@ class TestBenchmarkDemo:
         mock_client.messages.create = mock_anthropic_evaluation
 
         # Setup: Create fixture answer directory
-        fixture_source = Path(__file__).parent.parent / "results" / "mcp-clickhouse" / "20260128" / "answers"
+        fixture_source = Path(__file__).parent.parent / "results" / "mcp-clickhouse" / "latest" / "answers"
 
         # Mock batch processor to copy real fixture files instead of calling agent
         run_counter = {"count": 0}  # Track which run we're on

--- a/tests/test_drift_report.py
+++ b/tests/test_drift_report.py
@@ -1,0 +1,143 @@
+import json
+
+from cbioportal_mcp_qa.drift_report import (
+    build_drift_summary,
+    main,
+    render_markdown,
+)
+
+
+def _write_eval_csv(path, rows):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lines = [
+        "# Average correctness_score: 2.50,,,,",
+        "question,correctness_score,completeness_score",
+    ]
+    for question, correctness, completeness in rows:
+        lines.append(f"{question},{correctness},{completeness}")
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def test_build_drift_summary_detects_per_question_regression(temp_dir):
+    current_dir = temp_dir / "results" / "agent" / "20260617" / "eval"
+    baseline_dir = temp_dir / "results" / "agent" / "latest" / "eval"
+
+    _write_eval_csv(
+        baseline_dir / "evaluation_20260616.csv",
+        [
+            ("Question A", 3, 3),
+            ("Question B", 3, 3),
+        ],
+    )
+    _write_eval_csv(
+        current_dir / "evaluation_20260617.csv",
+        [
+            ("Question A", 1, 3),
+            ("Question B", 3, 2),
+        ],
+    )
+
+    summary = build_drift_summary(
+        agent_type="agent",
+        current_eval_dir=current_dir,
+        baseline_eval_dir=baseline_dir,
+        drop_threshold=1.0,
+    )
+
+    assert summary.has_regressions
+    assert summary.current_averages["correctness_score"] == 2.0
+    assert summary.baseline_averages["correctness_score"] == 3.0
+    assert summary.average_deltas["correctness_score"] == -1.0
+    assert summary.regressions == [
+        {
+            "question": "Question A",
+            "metric": "correctness_score",
+            "baseline": 3.0,
+            "current": 1.0,
+            "delta": -2.0,
+        },
+        {
+            "question": "Question B",
+            "metric": "completeness_score",
+            "baseline": 3.0,
+            "current": 2.0,
+            "delta": -1.0,
+        },
+    ]
+
+
+def test_render_markdown_includes_scores_and_regressions(temp_dir):
+    current_dir = temp_dir / "current"
+    baseline_dir = temp_dir / "baseline"
+    _write_eval_csv(baseline_dir / "evaluation_20260616.csv", [("Question A", 3, 3)])
+    _write_eval_csv(current_dir / "evaluation_20260617.csv", [("Question A", 2, 3)])
+
+    summary = build_drift_summary(
+        agent_type="agent",
+        current_eval_dir=current_dir,
+        baseline_eval_dir=baseline_dir,
+        drop_threshold=1.0,
+    )
+    markdown = render_markdown(summary)
+
+    assert "# Drift Report: `agent`" in markdown
+    assert "| correctness_score | 2.00 | 3.00 | -1.00 |" in markdown
+    assert "| Question A | correctness_score | 3.00 | 2.00 | -1.00 |" in markdown
+
+
+def test_main_writes_markdown_and_json(temp_dir):
+    current_dir = temp_dir / "current"
+    baseline_dir = temp_dir / "baseline"
+    output_markdown = temp_dir / "drift.md"
+    output_json = temp_dir / "drift.json"
+    _write_eval_csv(baseline_dir / "evaluation_20260616.csv", [("Question A", 3, 3)])
+    _write_eval_csv(current_dir / "evaluation_20260617.csv", [("Question A", 3, 3)])
+
+    exit_code = main(
+        [
+            "--agent-type",
+            "agent",
+            "--current-eval-dir",
+            str(current_dir),
+            "--baseline-eval-dir",
+            str(baseline_dir),
+            "--output-markdown",
+            str(output_markdown),
+            "--output-json",
+            str(output_json),
+        ]
+    )
+
+    assert exit_code == 0
+    assert output_markdown.exists()
+    report = json.loads(output_json.read_text(encoding="utf-8"))
+    assert report["agent_type"] == "agent"
+    assert report["has_regressions"] is False
+
+
+def test_build_drift_summary_ignores_blank_question_rows(temp_dir):
+    current_dir = temp_dir / "current"
+    baseline_dir = temp_dir / "baseline"
+    _write_eval_csv(
+        baseline_dir / "evaluation_20260616.csv",
+        [
+            ("Question A", 3, 3),
+            ("", 1, 1),
+        ],
+    )
+    _write_eval_csv(
+        current_dir / "evaluation_20260617.csv",
+        [
+            ("Question A", 3, 3),
+            ("", 1, 1),
+        ],
+    )
+
+    summary = build_drift_summary(
+        agent_type="agent",
+        current_eval_dir=current_dir,
+        baseline_eval_dir=baseline_dir,
+        drop_threshold=1.0,
+    )
+
+    assert summary.regressions == []


### PR DESCRIPTION
## Summary
- add a scheduled/manual Nightly Drift Benchmark workflow that runs existing benchmark targets and uploads results
- add a drift_report utility that compares nightly evaluation CSVs against results/{agent}/latest baselines and writes Markdown/JSON reports
- document required secrets, manual inputs, uploaded artifacts, and target-specific drift interpretation
- restore benchmark compatibility for reproducibility callers and update the demo test fixture path to the checked-in latest baseline

## Default nightly behavior
- schedule: daily at 07:00 UTC
- agents: `mcp-clickhouse,mcp-navigator-agent`
- questions: `1-20` canary range
- regression threshold: 1.0 score drop per question
- monitoring-first: workflow does not fail on detected regressions unless `fail_on_regression` is enabled

## Required secrets
- `ANTHROPIC_API_KEY`
- `MCP_CLICKHOUSE_AGENT_URL`
- `CBIOPORTAL_MCP_AGENT_URL`

## Test plan
- `UV_CACHE_DIR=/private/tmp/uv-cache uv run python -m cbioportal_mcp_qa.drift_report --agent-type mcp-clickhouse --current-eval-dir results/mcp-clickhouse/latest/eval --baseline-eval-dir results/mcp-clickhouse/latest/eval --output-markdown /private/tmp/drift-report-smoke.md --output-json /private/tmp/drift-report-smoke.json`
- `UV_CACHE_DIR=/private/tmp/uv-cache uv run --extra dev pytest`
- `git diff --check`