### PR TITLE
Default to Claude Sonnet 5

### DIFF
--- a/agents/docker-compose.yml
+++ b/agents/docker-compose.yml
@@ -53,8 +53,8 @@ services:
       # Anthropic API (used when USE_BEDROCK=false)
       - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}
       # Model configuration
-      - DEFAULT_MODEL=${DEFAULT_MODEL:-claude-sonnet-4-5-20250929}
-      - DEFAULT_BEDROCK_MODEL=${DEFAULT_BEDROCK_MODEL:-us.anthropic.claude-sonnet-4-5-20250929-v1:0}
+      - DEFAULT_MODEL=${DEFAULT_MODEL:-claude-sonnet-5}
+      - DEFAULT_BEDROCK_MODEL=${DEFAULT_BEDROCK_MODEL:-global.anthropic.claude-sonnet-5}
       # The connection to your MCP server
       - MCP_SERVER_URL=http://mcp-clickhouse:8000/mcp
       - MOCK_EMPTY_MCP=false
@@ -81,8 +81,8 @@ services:
       # Anthropic API (used when USE_BEDROCK=false)
       - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}
       # Model configuration
-      - DEFAULT_MODEL=${DEFAULT_MODEL:-claude-sonnet-4-5-20250929}
-      - DEFAULT_BEDROCK_MODEL=${DEFAULT_BEDROCK_MODEL:-us.anthropic.claude-sonnet-4-5-20250929-v1:0}
+      - DEFAULT_MODEL=${DEFAULT_MODEL:-claude-sonnet-5}
+      - DEFAULT_BEDROCK_MODEL=${DEFAULT_BEDROCK_MODEL:-global.anthropic.claude-sonnet-5}
       # The connection to cBioPortal Navigator MCP server
       - MCP_SERVER_URL=http://cbioportal-navigator:8002/mcp
     ports:
@@ -108,8 +108,8 @@ services:
       # Anthropic API (used when USE_BEDROCK=false)
       - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}
       # Model configuration
-      - DEFAULT_MODEL=${DEFAULT_MODEL:-claude-sonnet-4-5-20250929}
-      - DEFAULT_BEDROCK_MODEL=${DEFAULT_BEDROCK_MODEL:-us.anthropic.claude-sonnet-4-5-20250929-v1:0}
+      - DEFAULT_MODEL=${DEFAULT_MODEL:-claude-sonnet-5}
+      - DEFAULT_BEDROCK_MODEL=${DEFAULT_BEDROCK_MODEL:-global.anthropic.claude-sonnet-5}
       - DEFAULT_TEMPERATURE=${DEFAULT_TEMPERATURE:-0.0}
       - DEFAULT_MAX_OUTPUT_TOKENS=${DEFAULT_MAX_OUTPUT_TOKENS:-4096}
       # No MCP tools for null agent
@@ -136,8 +136,8 @@ services:
       # Anthropic API (used when USE_BEDROCK=false)
       - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}
       # Model configuration
-      - DEFAULT_MODEL=${DEFAULT_MODEL:-claude-sonnet-4-5-20250929}
-      - DEFAULT_BEDROCK_MODEL=${DEFAULT_BEDROCK_MODEL:-us.anthropic.claude-sonnet-4-5-20250929-v1:0}
+      - DEFAULT_MODEL=${DEFAULT_MODEL:-claude-sonnet-5}
+      - DEFAULT_BEDROCK_MODEL=${DEFAULT_BEDROCK_MODEL:-global.anthropic.claude-sonnet-5}
       - DEFAULT_TEMPERATURE=${DEFAULT_TEMPERATURE:-0.0}
       - DEFAULT_MAX_OUTPUT_TOKENS=${DEFAULT_MAX_OUTPUT_TOKENS:-4096}
       # No MCP tools for null agent

--- a/agents/env.template
+++ b/agents/env.template
@@ -20,7 +20,7 @@ CLICKHOUSE_DATABASE=your-clickhouse-database
 CLICKHOUSE_SECURE=true
 
 # Model Configuration (optional)
-DEFAULT_MODEL=claude-sonnet-4-5-20250929
-DEFAULT_BEDROCK_MODEL=us.anthropic.claude-sonnet-4-5-20250929-v1:0
+DEFAULT_MODEL=claude-sonnet-5
+DEFAULT_BEDROCK_MODEL=global.anthropic.claude-sonnet-5
 DEFAULT_TEMPERATURE=0.0
 DEFAULT_MAX_OUTPUT_TOKENS=4096

--- a/src/cbioportal_mcp_qa/evaluation.py
+++ b/src/cbioportal_mcp_qa/evaluation.py
@@ -132,9 +132,9 @@ def evaluate(client, question: str, expected: str,
     # Select model based on client type if not explicitly provided
     if model is None:
         if use_bedrock:
-            model = "us.anthropic.claude-sonnet-4-5-20250929-v1:0"
+            model = "global.anthropic.claude-sonnet-5"
         else:
-            model = "claude-sonnet-4-5-20250929"
+            model = "claude-sonnet-5"
 
     max_retries = 3
     for attempt in range(max_retries):
@@ -338,9 +338,9 @@ Provide your output as a JSON object:
     # Select model based on client type if not explicitly provided
     if model is None:
         if use_bedrock:
-            model = "us.anthropic.claude-sonnet-4-5-20250929-v1:0"
+            model = "global.anthropic.claude-sonnet-5"
         else:
-            model = "claude-sonnet-4-5-20250929"
+            model = "claude-sonnet-5"
 
     max_retries = 3
     for attempt in range(max_retries):

--- a/src/cbioportal_mcp_qa/main.py
+++ b/src/cbioportal_mcp_qa/main.py
@@ -81,8 +81,8 @@ def shared_options(f):
         click.option(
             "--model",
             "-m",
-            default="anthropic:claude-sonnet-4-5-20250929",
-            help="Model to use (default: claude-sonnet-4-5-20250929 for Anthropic, e.g., qwen3:8b for Ollama)",
+            default="anthropic:claude-sonnet-5",
+            help="Model to use (default: claude-sonnet-5 for Anthropic, e.g., qwen3:8b for Ollama)",
         ),
         click.option(
             "--use-ollama",


### PR DESCRIPTION
## Summary

Flip the Docker-CLI agent stack's default model from Claude Sonnet 4.5 to Claude Sonnet 5:

- \`agents/docker-compose.yml\` — all four services (\`DEFAULT_MODEL\` + \`DEFAULT_BEDROCK_MODEL\`)
- \`agents/env.template\` — mirror
- \`src/cbioportal_mcp_qa/main.py\` — CLI \`--model\` default
- \`src/cbioportal_mcp_qa/evaluation.py\` — judge model default in both \`evaluate()\` paths

## Why

Sonnet 5 introductory pricing (\$2/\$10 per MTok in/out) is in effect through **2026-08-31**, then reverts to \$3/\$15 (same as Sonnet 4.5). Sonnet 5 uses a denser tokenizer (~30% more tokens per unit of English text) so:
- During promo: ~13% cheaper per unit of real text
- After promo: ~30% more expensive per unit of real text

Running the QA/benchmark stack on Sonnet 5 now gives us apples-to-apples numbers to justify (or reverse) the prod cutover before the promo ends.

## Model IDs picked

- Bedrock: \`global.anthropic.claude-sonnet-5\` — the global inference profile has no regional premium, unlike \`us.\` which adds 10% on Sonnet 4.5+ models. Both are ACTIVE in the 490004633549 account.
- Anthropic direct: \`claude-sonnet-5\` — no date suffix; matches the ID at claude.com/pricing.

## Alignment with LibreChat

Matches the beta LibreChat canary in knowledgesystems/knowledgesystems-k8s-deployment#535. Per \`~/projects/mcp/CLAUDE.md\`, both surfaces must run the same model. Prod LibreChat stays on Sonnet 4.5 for now; that flip is a separate PR against \`portal-configuration\` once the beta canary and Docker CLI benchmark both look good.

## Test plan

- [ ] \`docker compose config\` renders the four services with the new model defaults
- [ ] \`docker compose run --rm mcp-agent --help\` shows Sonnet 5 in the resolved env
- [ ] One benchmark run against Bedrock resolves to \`global.anthropic.claude-sonnet-5\` and completes without errors
- [ ] One benchmark run against Anthropic direct resolves to \`claude-sonnet-5\`