### PR TITLE
Default to Claude Sonnet 4.6

### DIFF
--- a/agents/docker-compose.yml
+++ b/agents/docker-compose.yml
@@ -53,8 +53,8 @@ services:
       # Anthropic API (used when USE_BEDROCK=false)
       - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}
       # Model configuration
-      - DEFAULT_MODEL=${DEFAULT_MODEL:-claude-sonnet-4-5-20250929}
-      - DEFAULT_BEDROCK_MODEL=${DEFAULT_BEDROCK_MODEL:-us.anthropic.claude-sonnet-4-5-20250929-v1:0}
+      - DEFAULT_MODEL=${DEFAULT_MODEL:-claude-sonnet-4-6}
+      - DEFAULT_BEDROCK_MODEL=${DEFAULT_BEDROCK_MODEL:-us.anthropic.claude-sonnet-4-6}
       # The connection to your MCP server
       - MCP_SERVER_URL=http://mcp-clickhouse:8000/mcp
       - MOCK_EMPTY_MCP=false
@@ -81,8 +81,8 @@ services:
       # Anthropic API (used when USE_BEDROCK=false)
       - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}
       # Model configuration
-      - DEFAULT_MODEL=${DEFAULT_MODEL:-claude-sonnet-4-5-20250929}
-      - DEFAULT_BEDROCK_MODEL=${DEFAULT_BEDROCK_MODEL:-us.anthropic.claude-sonnet-4-5-20250929-v1:0}
+      - DEFAULT_MODEL=${DEFAULT_MODEL:-claude-sonnet-4-6}
+      - DEFAULT_BEDROCK_MODEL=${DEFAULT_BEDROCK_MODEL:-us.anthropic.claude-sonnet-4-6}
       # The connection to cBioPortal Navigator MCP server
       - MCP_SERVER_URL=http://cbioportal-navigator:8002/mcp
     ports:
@@ -108,8 +108,8 @@ services:
       # Anthropic API (used when USE_BEDROCK=false)
       - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}
       # Model configuration
-      - DEFAULT_MODEL=${DEFAULT_MODEL:-claude-sonnet-4-5-20250929}
-      - DEFAULT_BEDROCK_MODEL=${DEFAULT_BEDROCK_MODEL:-us.anthropic.claude-sonnet-4-5-20250929-v1:0}
+      - DEFAULT_MODEL=${DEFAULT_MODEL:-claude-sonnet-4-6}
+      - DEFAULT_BEDROCK_MODEL=${DEFAULT_BEDROCK_MODEL:-us.anthropic.claude-sonnet-4-6}
       - DEFAULT_TEMPERATURE=${DEFAULT_TEMPERATURE:-0.0}
       - DEFAULT_MAX_OUTPUT_TOKENS=${DEFAULT_MAX_OUTPUT_TOKENS:-4096}
       # No MCP tools for null agent
@@ -136,8 +136,8 @@ services:
       # Anthropic API (used when USE_BEDROCK=false)
       - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}
       # Model configuration
-      - DEFAULT_MODEL=${DEFAULT_MODEL:-claude-sonnet-4-5-20250929}
-      - DEFAULT_BEDROCK_MODEL=${DEFAULT_BEDROCK_MODEL:-us.anthropic.claude-sonnet-4-5-20250929-v1:0}
+      - DEFAULT_MODEL=${DEFAULT_MODEL:-claude-sonnet-4-6}
+      - DEFAULT_BEDROCK_MODEL=${DEFAULT_BEDROCK_MODEL:-us.anthropic.claude-sonnet-4-6}
       - DEFAULT_TEMPERATURE=${DEFAULT_TEMPERATURE:-0.0}
       - DEFAULT_MAX_OUTPUT_TOKENS=${DEFAULT_MAX_OUTPUT_TOKENS:-4096}
       # No MCP tools for null agent

--- a/agents/env.template
+++ b/agents/env.template
@@ -20,7 +20,7 @@ CLICKHOUSE_DATABASE=your-clickhouse-database
 CLICKHOUSE_SECURE=true
 
 # Model Configuration (optional)
-DEFAULT_MODEL=claude-sonnet-4-5-20250929
-DEFAULT_BEDROCK_MODEL=us.anthropic.claude-sonnet-4-5-20250929-v1:0
+DEFAULT_MODEL=claude-sonnet-4-6
+DEFAULT_BEDROCK_MODEL=us.anthropic.claude-sonnet-4-6
 DEFAULT_TEMPERATURE=0.0
 DEFAULT_MAX_OUTPUT_TOKENS=4096

--- a/src/cbioportal_mcp_qa/evaluation.py
+++ b/src/cbioportal_mcp_qa/evaluation.py
@@ -132,9 +132,9 @@ def evaluate(client, question: str, expected: str,
     # Select model based on client type if not explicitly provided
     if model is None:
         if use_bedrock:
-            model = "us.anthropic.claude-sonnet-4-5-20250929-v1:0"
+            model = "us.anthropic.claude-sonnet-4-6"
         else:
-            model = "claude-sonnet-4-5-20250929"
+            model = "claude-sonnet-4-6"
 
     max_retries = 3
     for attempt in range(max_retries):
@@ -338,9 +338,9 @@ Provide your output as a JSON object:
     # Select model based on client type if not explicitly provided
     if model is None:
         if use_bedrock:
-            model = "us.anthropic.claude-sonnet-4-5-20250929-v1:0"
+            model = "us.anthropic.claude-sonnet-4-6"
         else:
-            model = "claude-sonnet-4-5-20250929"
+            model = "claude-sonnet-4-6"
 
     max_retries = 3
     for attempt in range(max_retries):

--- a/src/cbioportal_mcp_qa/main.py
+++ b/src/cbioportal_mcp_qa/main.py
@@ -81,8 +81,8 @@ def shared_options(f):
         click.option(
             "--model",
             "-m",
-            default="anthropic:claude-sonnet-4-5-20250929",
-            help="Model to use (default: claude-sonnet-4-5-20250929 for Anthropic, e.g., qwen3:8b for Ollama)",
+            default="anthropic:claude-sonnet-4-6",
+            help="Model to use (default: claude-sonnet-4-6 for Anthropic, e.g., qwen3:8b for Ollama)",
         ),
         click.option(
             "--use-ollama",


### PR DESCRIPTION
## Summary

Flip Docker-CLI benchmark stack defaults from Sonnet 4.5 to Sonnet 4.6:

- \`agents/docker-compose.yml\` — all four services
- \`agents/env.template\` — mirror
- \`src/cbioportal_mcp_qa/main.py\` — CLI \`--model\` default
- \`src/cbioportal_mcp_qa/evaluation.py\` — judge model default in both \`evaluate()\` paths

## Why

Aligns with the LibreChat prod cutover (knowledgesystems/portal-configuration#44). Sonnet 4.6 is same \$3/\$15 pricing as 4.5 on Bedrock, invokable today with no data-residency or Marketplace issues.

## Model IDs

Bedrock target uses the newer short-form ID that starts at Sonnet 4.6 (no date, no \`-v1:0\`):

- Anthropic direct: \`claude-sonnet-4-6\`
- Bedrock: \`us.anthropic.claude-sonnet-4-6\`

The \`global.\` prefix stays unusable on account 490004633549 due to data-residency policy — must use \`us.\`.

## Note on prior PR #41

Closed unmerged after the Sonnet 5 attempt found the Marketplace-subscribe block. This PR is the successor targeting the working 4.6 model instead.

## Test plan

- [ ] \`docker compose config\` renders four services with the new defaults
- [ ] Benchmark run against Bedrock resolves to \`us.anthropic.claude-sonnet-4-6\` and completes
- [ ] Benchmark run against Anthropic direct resolves to \`claude-sonnet-4-6\`